### PR TITLE
Comment out fp16 in config

### DIFF
--- a/projects/configs/maptr/maptr_tiny_r50_24e.py
+++ b/projects/configs/maptr/maptr_tiny_r50_24e.py
@@ -306,5 +306,5 @@ log_config = dict(
         dict(type='TextLoggerHook'),
         dict(type='TensorboardLoggerHook')
     ])
-fp16 = dict(loss_scale=512.)
+# fp16 = dict(loss_scale=512.)
 checkpoint_config = dict(interval=1)


### PR DESCRIPTION
## Summary
- disable fp16 in `maptr_tiny_r50_24e.py`

## Testing
- `python tools/train.py projects/configs/maptr/maptr_tiny_r50_24e.py --cfg-options runner.max_epochs=1 --no-validate` *(fails: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_687274781830832488a3ac0c08afd043